### PR TITLE
feat(patch): remove relax star multiplier

### DIFF
--- a/OsuHook/Osu/Stubs/Beatmap.cs
+++ b/OsuHook/Osu/Stubs/Beatmap.cs
@@ -1,0 +1,41 @@
+// ReSharper disable InconsistentNaming
+
+
+using System;
+using OsuHook.OpcodeUtil;
+using static System.Reflection.Emit.OpCodes;
+
+namespace OsuHook.Osu.Stubs
+{
+    /// <summary>
+    ///     Original: <c>osu.GameplayElements.Beatmaps.Beatmap</c>
+    ///     b20240102.2: <c>#=zIVNEPkxvRBTQq2q8UIretksQbxQMCb4bKoMXjCtU9TcZ</c>
+    /// </summary>
+    internal static class Beatmap
+    {
+        /// <summary>
+        ///     Compiler extracted method that retrieves cached difficulty ratings for each star-differing mod combination.
+        ///     Original: <c>method_1(PlayModes, Mods)</c>
+        ///     b20240102.2:
+        ///     <c>\u0005\u2004\u200A\u2004\u2006\u2006\u200B\u200B\u2003\u2000\u200B\u2003\u200A\u2004\u2006\u200A\u2006\u2009\u200A\u2006\u200B\u200B\u2002\u2002\u200B\u2007\u2001\u2008</c>
+        /// </summary>
+        public static readonly LazySignature method_1 = new LazySignature(
+            "Beatmap#method_1",
+            new[]
+            {
+                Ldfld,
+                Ldarg_1,
+                Ldelem,
+                Ldarg_2,
+                Callvirt,
+                Brtrue_S,
+                Ldc_R8,
+                Ret,
+                Ldarg_0,
+                Ldfld,
+            }
+        );
+
+        public static Type ClassType => method_1.Reference.DeclaringType;
+    }
+}

--- a/OsuHook/Osu/Stubs/BeatmapDifficultyCalculatorOsu.cs
+++ b/OsuHook/Osu/Stubs/BeatmapDifficultyCalculatorOsu.cs
@@ -1,0 +1,34 @@
+using OsuHook.OpcodeUtil;
+using static System.Reflection.Emit.OpCodes;
+
+namespace OsuHook.Osu.Stubs
+{
+    /// <summary>
+    ///     Original:
+    ///     <c>osu.GameplayElements.Beatmaps.BeatmapDifficultyCalculatorOsu</c>
+    ///     b20240102.2:
+    ///     <c>#=zrhWGiKrl1UmqBImnyQby2bTT1qD0n4Aqjlj0y0m3pOv9JLdOLp5b8fDCCHT38Qmkt86FZwV3L5nHClHCcPTOKMeuFyvmbJz9qg==</c>
+    /// </summary>
+    internal static class BeatmapDifficultyCalculatorOsu
+    {
+        /// <summary>
+        ///     Original: <c>CreateDifficultyAttributes</c> is highly likely. ref:
+        ///     https://github.com/ppy/osu/blob/fbc40ffc65930f1e36bb048c73623dbbd0e23062/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs#L53-L58
+        ///     b20240102.2: <c>#=z5tW2q8sXvXTj$c1S1Eho4Gc=</c>
+        /// </summary>
+        public static readonly LazySignature Method1 = new LazySignature(
+            "BeatmapDifficultyCalculatorOsu#CreateDifficultyAttributes",
+            new[]
+            {
+                Ldarg_0,
+                Ldfld,
+                Ldfld,
+                Call,
+                Ldc_I4,
+                And,
+                Ldc_I4_0,
+                Ble_S,
+            }
+        );
+    }
+}

--- a/OsuHook/Patches/PatchDisableRelaxStarMultiplier.cs
+++ b/OsuHook/Patches/PatchDisableRelaxStarMultiplier.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+
+// ReSharper disable UnusedType.Global UnusedMember.Local InconsistentNaming
+
+namespace OsuHook.Patches
+{
+    /// <summary>
+    ///     Disable the effect Relax has on a beatmap's star rating.
+    ///     Remove the following code from <c>BeatmapDifficultyCalculatorOsu</c>:
+    ///     <code><![CDATA[
+    ///          if ((this.#=zu_MPb7Rzosaq.#=zRx1ESxOo8Jm0 & Mods.Relax) > Mods.None)
+    ///          {
+    ///              num *= 0.9;
+    ///              num2 = 0.0;
+    ///              num3 *= 0.7;
+    ///          }
+    ///      ]]></code>
+    /// </summary>
+    // [HarmonyPatch]
+    public class PatchDisableRelaxStarMultiplier : BasePatch
+    {
+        // private static readonly OpCode[] Signature =
+        // {
+        //     // Stloc_1,
+        //     // // if statement
+        //     // Ldarg_0,
+        //     // Ldfld,
+        //     // Ldfld,
+        //     // Call,
+        //     // Ldc_I4,
+        //     // And,
+        //     // Ldc_I4_0,
+        //     // Ble_S, // jumps to just past the end of this signature
+        //     // if body
+        //     Ldloc_0,
+        //     Ldc_R8,
+        //     Mul,
+        //     Stloc_0,
+        //     Ldc_R8,
+        //     Stloc_2,
+        //     Ldloc_1,
+        //     Ldc_R8,
+        //     Mul,
+        //     Stloc_1,
+        // };
+        //
+        // [HarmonyTargetMethod]
+        // private static MethodBase Target() => OpCodeMatcher.FindMethodBySignature(Signature);
+        //
+        // [HarmonyTranspiler]
+        // private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) =>
+        //     NoopSignature(instructions, Signature);
+
+
+        // [HarmonyTargetMethod]
+        // private static MethodBase Target() => Beatmap.method_1.Reference;
+
+        // [HarmonyPrefix]
+        // private static void Before(ref object[] __args)
+        // {
+        // const int modRelax = 1 << 7;
+        // __args[1] = (int)__args[1] & ~modRelax;
+        // Console.WriteLine((int)__args[1]);
+        // }
+
+        [HarmonyTargetMethod]
+        private static MethodBase Target() =>
+            // AccessTools.Method(
+            // "#=zrhWGiKrl1UmqBImnyQby2bTT1qD0n4Aqjlj0y0m3pOv9JLdOLp5b8fDCCHT38Qmkt86FZwV3L5nHClHCcPTOKMeuFyvmbJz9qg==:#=zwdR$CuA8xPiHtvvxOy7Cs9c=");
+            // "#=zrhWGiKrl1UmqBImnyQby2bTT1qD0n4Aqjlj0y0m3pOv9JLdOLp5b8fDCCHT38Qmkt86FZwV3L5nHClHCcPTOKMeuFyvmbJz9qg==:#=zNQvrKrrttCZ8");
+            // );
+            AccessTools.TypeByName("#=zEPx_kXmLvW4NAaszRD_NEFjlF9PqbC4AOTGb$KGzM3i2SAtjjvCpN8Dw$20OiPKfgQwXbHY=")
+                .GetRuntimeMethods()
+                .Single(mtd => mtd.Name == "#=zNQvrKrrttCZ8" && mtd.GetParameters().Length == 3);
+
+        [HarmonyAfter]
+        private static void After(ref int __result)
+        {
+            Console.WriteLine($"here {__result}");
+            const int modRelax = 1 << 7;
+            __result &= ~modRelax;
+            Console.WriteLine($"here2 {__result}");
+        }
+    }
+}


### PR DESCRIPTION
osu! has recently changed the mod star multiplier system and nerfed the SR when relax is enabled into the ground making it completely useless as an indicator of map difficulty